### PR TITLE
Add missing carbon in perhydroisoquinoline

### DIFF
--- a/opensmiles.asciidoc
+++ b/opensmiles.asciidoc
@@ -454,7 +454,7 @@ forms a cyclic structure.
 |==================================================================================
 | Depiction                               | SMILES           | Name
 | image:depict/cyclohexane.gif[]          | `C1CCCCC1`       | cyclohexane
-| image:depict/perhydroisoquinoline.gif[] | `N1CC2CCCC2CC1`  | perhydroisoquinoline
+| image:depict/perhydroisoquinoline.gif[] | `N1CC2CCCCC2CC1` | perhydroisoquinoline
 |==================================================================================
 
 If a bond symbol is present between the atom and rnum, it can be


### PR DESCRIPTION
Unless I'm confused, the SMILES string given for perhydroisoquinoline (C₉H₁₇N) has only 8 carbons.